### PR TITLE
[PR] Simplify setup options

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - TensorFlowLiteSwift/CoreML (2.4.0):
     - TensorFlowLiteC/CoreML (= 2.4.0)
     - TensorFlowLiteSwift/Core (= 2.4.0)
-  - TFLiteSwift-Vision (0.1.0):
+  - TFLiteSwift-Vision (0.1.1):
     - TensorFlowLiteSwift/CoreML (~> 2.4.0)
 
 DEPENDENCIES:
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   TensorFlowLiteC: 09f8ac75a76caeadb19bcfa694e97454cc1ecf87
   TensorFlowLiteSwift: f062dc1178120100d825d7799fd9f115b4a37fee
-  TFLiteSwift-Vision: 1e717161d56b8f6a4c5db704e4579f565f4e5077
+  TFLiteSwift-Vision: e6a9b24d4cbede963638f442c58e1c7a7ca7bfd2
 
 PODFILE CHECKSUM: 15e854f5ea0c85523b45dbcf906f1dcb8c49e5de
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/Example/TFLiteSwift-Vision/ViewController.swift
+++ b/Example/TFLiteSwift-Vision/ViewController.swift
@@ -29,13 +29,14 @@ class ViewController: UIViewController, UINavigationControllerDelegate {
         
         let interpreterOptions = TFLiteVisionInterpreter.Options(
             modelName: "mobilenet_v2_1.0_224",
-            inputWidth: 224, inputHeight: 224,
-            normalization: .scaledNormalization
+            inputRankType: .bwhc,
+            normalization: .scaled(from: 0.0, to: 1.0)
         )
         visionInterpreter = TFLiteVisionInterpreter(options: interpreterOptions)
         
-        if let labelFilePath = Bundle.main.path(forResource: "labels_mobilenet_quant_v1_224", ofType: "txt") {
+         if let labelFilePath = Bundle.main.path(forResource: "labels_mobilenet_quant_v1_224", ofType: "txt") {
             labels = try? String(contentsOfFile: labelFilePath).split(separator: "\n").map { String($0) }
+            // labels?.remove(at: 0)
         }
         
         print(labels ?? "N/A labels")
@@ -73,7 +74,7 @@ extension ViewController: UIImagePickerControllerDelegate {
                 // inference
                 guard let outputs: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: inputData)?.first
                     else { fatalError("Cannot inference") }
-                
+                 
                 print(outputs.dimensions)
                 let predictedIndex: Int = Int(outputs.argmax())
                 


### PR DESCRIPTION
## Related Issue

#5 

## PR Points

- support uInt8 input type
- remove input size argument and setup input size when loading tflite model and get the input shape
- change normalization cases

### AS-IS

```swift
let interpreterOptions = TFLiteVisionInterpreter.Options(
    modelName: "mobilenet_v2_1.0_224",
    inputWidth: 224, inputHeight: 224,
    normalization: .scaledNormalization
)
```

### TO-BE

```swift
let interpreterOptions = TFLiteVisionInterpreter.Options(
    modelName: "mobilenet_v2_1.0_224",
    inputRankType: .bwhc,
    normalization: .scaled(from: 0.0, to: 1.0)
)
```