### PR TITLE
[PR] Simplify inference method

### DIFF
--- a/Example/TFLiteSwift-Vision/ViewController.swift
+++ b/Example/TFLiteSwift-Vision/ViewController.swift
@@ -14,10 +14,6 @@ class ViewController: UIViewController, UINavigationControllerDelegate {
     let picker = UIImagePickerController()
     
     var visionInterpreter: TFLiteVisionInterpreter?
-    
-    var preprocessOptions: PreprocessOptions {
-        return PreprocessOptions(cropArea: .squareAspectFill)
-    }
     var labels: [String]?
 
     @IBOutlet weak var mainImageView: UIImageView!
@@ -65,14 +61,8 @@ extension ViewController: UIImagePickerControllerDelegate {
             DispatchQueue(label: "com.tucan9389.inference", qos: .userInteractive).async { [weak self] in
                 guard let self = self else { return }
                 
-                let input: TFLiteVisionInput = .uiImage(uiImage: uiImage, preprocessOptions: self.preprocessOptions)
-                
-                // preprocess
-                guard let inputData: Data = self.visionInterpreter?.preprocess(with: input)
-                    else { fatalError("Cannot preprcess") }
-                
                 // inference
-                guard let outputs: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: inputData)?.first
+                guard let outputs: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: uiImage)
                     else { fatalError("Cannot inference") }
                  
                 print(outputs.dimensions)

--- a/TFLiteSwift-Vision/Classes/TFLiteVisionInterpreter.swift
+++ b/TFLiteSwift-Vision/Classes/TFLiteVisionInterpreter.swift
@@ -140,7 +140,7 @@ public class TFLiteVisionInterpreter {
         guard let inputWidth = inputWidth, let inputHeight = inputHeight else { return nil }
         
         let modelInputSize = CGSize(width: inputWidth, height: inputHeight)
-        guard let thumbnail = input.croppedPixelBuffer(with: modelInputSize) else { return nil }
+        guard let thumbnail = input.croppedPixelBuffer(with: modelInputSize, and: options.cropType) else { return nil }
         
         // Remove the alpha component from the image buffer to get the initialized `Data`.
         let byteCount = 1 * inputHeight * inputWidth * options.inputChannel
@@ -198,6 +198,20 @@ public class TFLiteVisionInterpreter {
         
         return outputTensors.map { TFLiteFlatArray(tensor: $0) }
     }
+    
+    public func inference(with uiImage: UIImage) -> TFLiteFlatArray<Float32>? {
+        let input: TFLiteVisionInput = .uiImage(uiImage: uiImage)
+        
+        // preprocess
+        guard let inputData: Data = preprocess(with: input)
+            else { fatalError("Cannot preprcess") }
+        
+        // inference
+        guard let output: TFLiteFlatArray<Float32> = inference(with: inputData)?.first
+            else { fatalError("Cannot inference") }
+        
+        return output
+    }
 }
 
 extension TFLiteVisionInterpreter {
@@ -218,6 +232,11 @@ extension TFLiteVisionInterpreter {
         case bcwh
     }
     
+    public enum CropType {
+        case customAspectFill(rect: CGRect)
+        case squareAspectFill
+    }
+    
     public struct Options {
         let modelName: String
         let threadCount: Int
@@ -229,6 +248,7 @@ extension TFLiteVisionInterpreter {
         var inputChannel: Int { return isGrayScale ? 1 : 3 }
         
         let normalization: NormalizationOptions
+        let cropType: CropType
         
         public init(
             modelName: String,
@@ -237,7 +257,8 @@ extension TFLiteVisionInterpreter {
             isQuantized: Bool = false,
             inputRankType: RankType = .bwhc,
             isGrayScale: Bool = false,
-            normalization: NormalizationOptions = .scaled(from: 0.0, to: 1.0)
+            normalization: NormalizationOptions = .scaled(from: 0.0, to: 1.0),
+            cropType: CropType = .squareAspectFill
         ) {
             self.modelName = modelName
             self.threadCount = threadCount
@@ -250,8 +271,10 @@ extension TFLiteVisionInterpreter {
             self.inputRankType = inputRankType
             self.isGrayScale = isGrayScale
             self.normalization = normalization
+            self.cropType = cropType
         }
     }
+    
 }
 
 extension TFLiteVisionInterpreter {
@@ -267,17 +290,3 @@ extension TFLiteVisionInterpreter {
         static let channel = 3 // rgb: 3, gray: 1
     }
 }
-
-public struct PreprocessOptions {
-    let cropArea: CropArea
-    
-    public init(cropArea: CropArea) {
-        self.cropArea = cropArea
-    }
-    
-    public enum CropArea {
-        case customAspectFill(rect: CGRect)
-        case squareAspectFill
-    }
-}
-


### PR DESCRIPTION
## Related Issue

#5 

## PR Points

- Add a simple inference method that can only UIImage as a input
- Remove `PreprocessOptions` type when using at inference and merge the functions at setup

### AS-IS

```swift
let input: TFLiteVisionInput = .uiImage(uiImage: uiImage, preprocessOptions: self.preprocessOptions)

// preprocess
guard let inputData: Data = self.visionInterpreter?.preprocess(with: input)
    else { fatalError("Cannot preprcess") }

// inference
guard let outputs: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: inputData)?.first
```

### TO-BE

```swift
// inference
guard let output: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: uiImage)
    else { fatalError("Cannot inference") }
```