### PR TITLE
[PR] Fix inference output as array type

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - TensorFlowLiteSwift/CoreML (2.4.0):
     - TensorFlowLiteC/CoreML (= 2.4.0)
     - TensorFlowLiteSwift/Core (= 2.4.0)
-  - TFLiteSwift-Vision (0.3.0):
+  - TFLiteSwift-Vision (0.2.1):
     - TensorFlowLiteSwift/CoreML (~> 2.4.0)
 
 DEPENDENCIES:
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   TensorFlowLiteC: 09f8ac75a76caeadb19bcfa694e97454cc1ecf87
   TensorFlowLiteSwift: f062dc1178120100d825d7799fd9f115b4a37fee
-  TFLiteSwift-Vision: f6a565e25ad728d4b6159cffe254d354a98e6f62
+  TFLiteSwift-Vision: 49e50fb6843fcdf0b624bf6553664f91a5378a1a
 
 PODFILE CHECKSUM: 5ff14c71b2e2a572cc89b34e448c394520b136d0
 

--- a/Example/TFLiteSwift-Vision/ViewController.swift
+++ b/Example/TFLiteSwift-Vision/ViewController.swift
@@ -62,7 +62,7 @@ extension ViewController: UIImagePickerControllerDelegate {
                 guard let self = self else { return }
                 
                 // inference
-                guard let output: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: uiImage)
+                guard let output: TFLiteFlatArray<Float32> = self.visionInterpreter?.inference(with: uiImage)?.first
                     else { fatalError("Cannot inference") }
                  
                 print(output.dimensions)

--- a/TFLiteSwift-Vision.podspec
+++ b/TFLiteSwift-Vision.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TFLiteSwift-Vision'
-  s.version          = '0.2.1'
+  s.version          = '0.2.2'
   s.summary          = 'A layer for vision\'s pre/post-processing when you are using TensorFlowLiteSwift'
 
 # This description is used to generate tags and improve search results.

--- a/TFLiteSwift-Vision/Classes/TFLiteFlatArray.swift
+++ b/TFLiteSwift-Vision/Classes/TFLiteFlatArray.swift
@@ -50,11 +50,11 @@ public class TFLiteFlatArray<Element: AdditiveArithmetic> {
         return result
     }
     
-    func element(at indexes: [Int]) -> Element {
+    public func element(at indexes: [Int]) -> Element {
         return array[flatIndex(indexes)]
     }
     
-    subscript(indexes: Int...) -> Element {
+    public subscript(indexes: Int...) -> Element {
         get { return array[flatIndex(indexes)] }
         set { array[flatIndex(indexes)] = newValue }
     }


### PR DESCRIPTION
## Related Issue

https://github.com/tucan9389/TFLiteSwift-Vision/issues/4

## PR Points

- use TFLiteSwift-Vision in [PoseEstimation-TFLiteSwift repo](https://github.com/tucan9389/PoseEstimation-TFLiteSwift) 
  - https://github.com/tucan9389/PoseEstimation-TFLiteSwift/pull/84
  - make output type of inference tensor array type
- update podspec version to 0.2.2